### PR TITLE
Add support for hyphens in dashboard name

### DIFF
--- a/grafana_api_client/__init__.py
+++ b/grafana_api_client/__init__.py
@@ -1,5 +1,4 @@
 from __future__ import unicode_literals
-
 import requests
 
 __all__ = map(str, ["GrafanaException", "GrafanaServerError", "GrafanaClientError",
@@ -60,6 +59,9 @@ class DeferredClientRequest(object):
         return self
 
     def make_request(self, method, payload):
+        if self.path_sections and 'dashboards' in self.path_sections[0]:
+            self.path_sections[-1] = self.path_sections[-1].replace('_', '-')
+
         endpoint = "/".join(self.path_sections)
         return self.client.make_raw_request(method, endpoint, payload)
 

--- a/tests/basic.py
+++ b/tests/basic.py
@@ -33,6 +33,8 @@ class TestCase(unittest.TestCase):
         self.assertEquals(gc.a.b[123](), ("GET", "a/b/123"))
         self.assertEquals(gc.a.b[123].replace(), ("PUT", "a/b/123"))
         self.assertEquals(gc.a.b[123].update(), ("PATCH", "a/b/123"))
+        self.assertEquals(gc.dashboards.db.c_d_e.get(), ("GET", "dashboards/db/c-d-e"))
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Technically you can use underscores in urls, but most people choose to use hyphens instead. 

Since python attribute names cannot contain hyphens and the client api uses python attributes to model the grafana api it is probably a good idea to convert underscores to hyphens implicitly. The drawback is of course that dashboard names cannot contain underscores.
