### PR TITLE
Revert "Add support for hyphens in dashboard name"

### DIFF
--- a/grafana_api_client/__init__.py
+++ b/grafana_api_client/__init__.py
@@ -1,4 +1,5 @@
 from __future__ import unicode_literals
+
 import requests
 import six
 
@@ -60,9 +61,6 @@ class DeferredClientRequest(object):
         return self
 
     def make_request(self, method, payload):
-        if self.path_sections and 'dashboards' in self.path_sections[0]:
-            self.path_sections[-1] = self.path_sections[-1].replace('_', '-')
-
         endpoint = "/".join(self.path_sections)
         return self.client.make_raw_request(method, endpoint, payload)
 

--- a/tests/basic.py
+++ b/tests/basic.py
@@ -34,8 +34,6 @@ class TestCase(unittest.TestCase):
         self.assertEquals(gc.a.b[123](), ("GET", "a/b/123"))
         self.assertEquals(gc.a.b[123].replace(), ("PUT", "a/b/123"))
         self.assertEquals(gc.a.b[123].update(), ("PATCH", "a/b/123"))
-        self.assertEquals(gc.dashboards.db.c_d_e.get(), ("GET", "dashboards/db/c-d-e"))
-
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This reverts commit 1086b429010615b12a8a2db5fc864f872dbe9601.

See my comment in https://github.com/htch/grafana_api_client/pull/6#issuecomment-262910121